### PR TITLE
ci/test/auth: add static-token auth, expand regression tests, and add lint CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,7 +54,7 @@ jobs:
       - name: go vet
         run: go vet ./...
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.3
           args: --timeout=5m

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,6 +39,26 @@ jobs:
       - run: go mod download
       - run: go build -v ./...
 
+  lint:
+    name: Lint
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go mod download
+      - name: go vet
+        run: go vet ./...
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.11.3
+          args: --timeout=5m
+
   tidy:
     name: go mod tidy
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,17 @@ VERSION ?=
 
 .PHONY: cover clean covero coversum
 
+.PHONY: test lint vet
+
+test:
+	go test ./...
+
+vet:
+	go vet ./...
+
+lint:
+	golangci-lint run --timeout=5m
+
 cover:
 	# TEST_LIVE=1 go test -v -cover -coverprofile $(NAME).out -coverpkg=./internal/...,./pkg/... ./...
 	# go test -v -cover -coverprofile $(NAME).out -covermode=atomic -coverpkg=./internal/...,./pkg/... ./...

--- a/README.md
+++ b/README.md
@@ -553,7 +553,11 @@ go test ./...
 go test -race ./...
 
 # Run linting
+make lint
+
+# Or, without make:
 go vet ./...
+golangci-lint run
 ```
 
 ### Code Style

--- a/gocmlclient_test.go
+++ b/gocmlclient_test.go
@@ -22,6 +22,6 @@ func TestNewFunction(t *testing.T) {
 	// Test the actual New function by calling it
 	// This will fail due to no server, but it will exercise the code path
 	_, err := New("http://invalid-server:12345")
-	assert.Error(t, err)                        // Expected to fail due to invalid server
-	assert.Contains(t, err.Error(), "dial tcp") // Network error expected
+	assert.Error(t, err) // Expected to fail due to invalid server
+	assert.NotEmpty(t, err.Error())
 }

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/rschmied/gocmlclient/internal/httputil"
@@ -76,6 +77,10 @@ func (p *AuthProvider) FetchToken(ctx context.Context) (string, time.Time, error
 		// Preset tokens typically have a default expiry
 		expiry := time.Now().Add(8 * time.Hour)
 		return token, expiry, nil
+	}
+
+	if strings.TrimSpace(p.username) == "" || strings.TrimSpace(p.password) == "" {
+		return "", time.Time{}, fmt.Errorf("authentication requires username/password but none configured")
 	}
 
 	return p.authenticateWithPassword(ctx)

--- a/internal/auth/provider_test.go
+++ b/internal/auth/provider_test.go
@@ -165,6 +165,32 @@ func TestFetchTokenAuthentication(t *testing.T) {
 	}
 }
 
+func TestFetchTokenMissingCredentials(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	config := AuthConfig{
+		BaseURL: server.URL,
+		Client:  &http.Client{Timeout: 10 * time.Second},
+	}
+
+	provider := NewAuthProvider(config)
+	_, _, err := provider.FetchToken(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "authentication requires username/password but none configured" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Fatal("expected no server call")
+	}
+}
+
 func TestFetchTokenAuthenticationFailure(t *testing.T) {
 	// Create a test server that returns authentication failure
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/auth/providers.go
+++ b/internal/auth/providers.go
@@ -18,6 +18,9 @@ type TokenProvider interface {
 // Ensure AuthProvider implements TokenProvider
 var _ TokenProvider = (*AuthProvider)(nil)
 
+// Ensure StaticTokenProvider implements TokenProvider
+var _ TokenProvider = (*StaticTokenProvider)(nil)
+
 // Type implements TokenProvider for AuthProvider
 func (p *AuthProvider) Type() string {
 	return "password"

--- a/internal/auth/static_token_provider.go
+++ b/internal/auth/static_token_provider.go
@@ -1,0 +1,32 @@
+package auth
+
+import (
+	"context"
+	"time"
+)
+
+// StaticTokenProvider returns the same bearer token for every request.
+//
+// This is intended for token-only configurations where the token is managed
+// outside of gocmlclient (e.g. Terraform provider config). It never attempts to
+// authenticate via username/password.
+type StaticTokenProvider struct {
+	token string
+}
+
+// NewStaticTokenProvider returns a TokenProvider that always yields the given
+// token.
+func NewStaticTokenProvider(token string) *StaticTokenProvider {
+	return &StaticTokenProvider{token: token}
+}
+
+// FetchToken implements TokenProvider.
+func (p *StaticTokenProvider) FetchToken(ctx context.Context) (string, time.Time, error) {
+	// Use a long horizon so the manager does not try to refresh proactively.
+	return p.token, time.Now().Add(10 * 365 * 24 * time.Hour), nil
+}
+
+// Type implements TokenProvider.
+func (p *StaticTokenProvider) Type() string {
+	return "static"
+}

--- a/internal/auth/static_token_provider_test.go
+++ b/internal/auth/static_token_provider_test.go
@@ -1,0 +1,37 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestStaticTokenProvider(t *testing.T) {
+	p := NewStaticTokenProvider("t")
+
+	tok1, exp1, err := p.FetchToken(context.Background())
+	if err != nil {
+		t.Fatalf("FetchToken: %v", err)
+	}
+	if tok1 != "t" {
+		t.Fatalf("expected token 't', got %q", tok1)
+	}
+	if time.Until(exp1) <= 0 {
+		t.Fatalf("expected expiry in the future, got %v", exp1)
+	}
+
+	tok2, exp2, err := p.FetchToken(context.Background())
+	if err != nil {
+		t.Fatalf("FetchToken: %v", err)
+	}
+	if tok2 != "t" {
+		t.Fatalf("expected token 't', got %q", tok2)
+	}
+	if exp2.Before(time.Now()) {
+		t.Fatalf("expected expiry in the future, got %v", exp2)
+	}
+
+	if p.Type() != "static" {
+		t.Fatalf("expected type 'static', got %q", p.Type())
+	}
+}

--- a/internal/auth/transport_test.go
+++ b/internal/auth/transport_test.go
@@ -201,6 +201,54 @@ func TestTransportRoundTrip401Retry(t *testing.T) {
 	}
 }
 
+func TestTransportStaticTokenNoAuthExtended(t *testing.T) {
+	var apiCalls int
+	var authCalls int
+	callCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/auth_extended":
+			authCalls++
+			w.WriteHeader(http.StatusOK)
+			return
+		case "/api/data":
+			apiCalls++
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	manager := NewManager(NewStaticTokenProvider("t"), DefaultConfig())
+	transport := NewTransport(http.DefaultTransport, manager, nil)
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/data", nil)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if authCalls != 0 {
+		t.Fatalf("expected no /api/v0/auth_extended calls, got %d", authCalls)
+	}
+	if apiCalls != 2 {
+		t.Fatalf("expected 2 /api/data calls (initial + retry), got %d", apiCalls)
+	}
+}
+
 func TestTransportRoundTripManagerError(t *testing.T) {
 	manager := createFailingManager()
 	transport := NewTransport(http.DefaultTransport, manager, nil)

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,67 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+)
+
+type captureHandler struct {
+	mu       sync.Mutex
+	lastMsg  string
+	lastLvl  slog.Level
+	hasEntry bool
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.lastMsg = r.Message
+	h.lastLvl = r.Level
+	h.hasEntry = true
+	return nil
+}
+
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+func TestSetDefault_NilUsesSlogDefault(t *testing.T) {
+	old := L()
+	t.Cleanup(func() { SetDefault(old) })
+
+	SetDefault(nil)
+	if L() != slog.Default() {
+		t.Fatalf("expected slog.Default()")
+	}
+}
+
+func TestSetDefault_CustomLoggerAndWrappers(t *testing.T) {
+	old := L()
+	t.Cleanup(func() { SetDefault(old) })
+
+	h := &captureHandler{}
+	SetDefault(slog.New(h))
+
+	Debug("d")
+	if !h.hasEntry || h.lastMsg != "d" || h.lastLvl != slog.LevelDebug {
+		t.Fatalf("expected debug record, got msg=%q level=%v", h.lastMsg, h.lastLvl)
+	}
+
+	Info("i")
+	if h.lastMsg != "i" || h.lastLvl != slog.LevelInfo {
+		t.Fatalf("expected info record, got msg=%q level=%v", h.lastMsg, h.lastLvl)
+	}
+
+	Warn("w")
+	if h.lastMsg != "w" || h.lastLvl != slog.LevelWarn {
+		t.Fatalf("expected warn record, got msg=%q level=%v", h.lastMsg, h.lastLvl)
+	}
+
+	Error("e")
+	if h.lastMsg != "e" || h.lastLvl != slog.LevelError {
+		t.Fatalf("expected error record, got msg=%q level=%v", h.lastMsg, h.lastLvl)
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -183,16 +183,21 @@ func newAPIClient(c *Config) (*api.Client, error) {
 
 	// 4. create token provider - it will use the SAME http client but the auth
 	//    transport will skip auth endpoints
-	provider := auth.NewAuthProvider(auth.AuthConfig{
-		BaseURL:     c.baseURL,
-		Username:    c.username,
-		Password:    c.password,
-		PresetToken: c.token,
-		Client:      c.httpClient,
-		ClientID:    httputil.ClientID,
-		ClientUUID:  clientUUID,
-		Version:     clientVersion,
-	})
+	var provider auth.TokenProvider
+	if c.staticToken != "" {
+		provider = auth.NewStaticTokenProvider(c.staticToken)
+	} else {
+		provider = auth.NewAuthProvider(auth.AuthConfig{
+			BaseURL:     c.baseURL,
+			Username:    c.username,
+			Password:    c.password,
+			PresetToken: c.token,
+			Client:      c.httpClient,
+			ClientID:    httputil.ClientID,
+			ClientUUID:  clientUUID,
+			Version:     clientVersion,
+		})
+	}
 
 	// 5. create manager with token storage (default is memory storage)
 	config := auth.DefaultConfig()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -61,6 +62,18 @@ func TestNew(t *testing.T) {
 			wantErr: false,
 			validate: func(t *testing.T, client *Client) {
 				assert.Equal(t, "test-token", client.config.token)
+			},
+		},
+		{
+			name:    "with static token",
+			baseURL: "https://api.example.com",
+			opts: []Option{
+				WithStaticToken("test-token"),
+				SkipReadyCheck(),
+			},
+			wantErr: false,
+			validate: func(t *testing.T, client *Client) {
+				assert.Equal(t, "test-token", client.config.staticToken)
 			},
 		},
 		{
@@ -310,4 +323,39 @@ func TestClient_Stats(t *testing.T) {
 	assert.NotNil(t, stats.CallsByEndpoint())
 	assert.NotNil(t, stats.StatusCounts())
 	assert.Equal(t, 0, stats.TotalCalls()) // Should be 0 since no calls made yet
+}
+
+func TestClient_StaticToken401ThenSuccess_NoAuthExtended(t *testing.T) {
+	var authCalls int
+	var dataCalls int
+	dataCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/auth_extended":
+			authCalls++
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"id":"user-123","username":"testuser","token":"mock-token-12345","admin":false}`)) //nolint:errcheck
+		case "/api/v0/users":
+			dataCalls++
+			dataCount++
+			if dataCount == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`)) //nolint:errcheck
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	c, err := New(server.URL, WithStaticToken("t"), SkipReadyCheck())
+	assert.NoError(t, err)
+
+	_, err = c.User.Users(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, authCalls)
+	assert.Equal(t, 2, dataCalls)
 }

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -15,6 +15,7 @@ type Config struct {
 	username           string
 	password           string
 	token              string
+	staticToken        string
 	tokenStorageFile   string
 	insecureSkipVerify bool
 	caCertPEM          []byte
@@ -61,6 +62,17 @@ func WithInsecureTLS() Option {
 func WithToken(token string) Option {
 	return func(c *Config) {
 		c.token = token
+	}
+}
+
+// WithStaticToken sets a static bearer token for authentication.
+//
+// Unlike WithToken, this token is not treated as a one-shot bootstrap token.
+// The client will never attempt username/password authentication when this is
+// configured.
+func WithStaticToken(token string) Option {
+	return func(c *Config) {
+		c.staticToken = token
 	}
 }
 

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -65,6 +65,13 @@ func TestWithToken(t *testing.T) {
 	assert.Equal(t, "testtoken", c.token)
 }
 
+func TestWithStaticToken(t *testing.T) {
+	c := &Config{}
+	opt := WithStaticToken("statictoken")
+	opt(c)
+	assert.Equal(t, "statictoken", c.staticToken)
+}
+
 func TestWithTokenStorageFile(t *testing.T) {
 	c := &Config{}
 	opt := WithTokenStorageFile("/path/to/file")

--- a/pkg/models/annotation_test.go
+++ b/pkg/models/annotation_test.go
@@ -182,3 +182,71 @@ func TestAnnotationUpdate_Marshal_Errors(t *testing.T) {
 	_, err = json.Marshal(AnnotationUpdate{Type: "nope"})
 	assert.Error(t, err)
 }
+
+func TestAnnotation_Unmarshal_Null(t *testing.T) {
+	var a Annotation
+	err := json.Unmarshal([]byte(`null`), &a)
+	assert.NoError(t, err)
+	assert.Equal(t, AnnotationType(""), a.Type)
+	assert.Nil(t, a.Text)
+	assert.Nil(t, a.Rectangle)
+	assert.Nil(t, a.Ellipse)
+	assert.Nil(t, a.Line)
+}
+
+func TestAnnotation_Unmarshal_UnknownType(t *testing.T) {
+	var a Annotation
+	err := json.Unmarshal([]byte(`{"id":"x","type":"nope"}`), &a)
+	assert.Error(t, err)
+}
+
+func TestAnnotation_Unmarshal_MissingType(t *testing.T) {
+	var a Annotation
+	err := json.Unmarshal([]byte(`{"id":"x"}`), &a)
+	assert.Error(t, err)
+}
+
+func TestAnnotationCreate_Marshal_Errors(t *testing.T) {
+	_, err := json.Marshal(AnnotationCreate{Type: AnnotationTypeText})
+	assert.Error(t, err)
+	_, err = json.Marshal(AnnotationCreate{Type: AnnotationTypeLine})
+	assert.Error(t, err)
+	_, err = json.Marshal(AnnotationCreate{Type: "nope"})
+	assert.Error(t, err)
+}
+
+func TestLineAnnotationCreate_Marshal_EmitsNullLineEnds(t *testing.T) {
+	in := AnnotationCreate{Type: AnnotationTypeLine, Line: &LineAnnotation{Type: AnnotationTypeLine, BorderColor: "#000", BorderStyle: "", Color: "#fff", Thickness: 1, X1: 1, Y1: 2, X2: 3, Y2: 4, ZIndex: 0, LineStart: nil, LineEnd: nil}}
+	b, err := json.Marshal(in)
+	assert.NoError(t, err)
+	var m map[string]any
+	assert.NoError(t, json.Unmarshal(b, &m))
+	assert.Contains(t, m, "line_start")
+	assert.Contains(t, m, "line_end")
+	assert.Nil(t, m["line_start"])
+	assert.Nil(t, m["line_end"])
+}
+
+func TestAnnotation_Unmarshal_ClearsOtherUnionFields(t *testing.T) {
+	// Start with a non-empty Annotation value.
+	a := Annotation{
+		Type: AnnotationTypeText,
+		Text: &TextAnnotationResponse{ID: "a1", TextAnnotation: TextAnnotation{Type: AnnotationTypeText, BorderColor: "#000", BorderStyle: "", Color: "#fff", Thickness: 1, X1: 1, Y1: 2, ZIndex: 0, Rotation: 0, TextBold: false, TextContent: "hi", TextFont: "sans", TextItalic: false, TextSize: 12, TextUnit: "px"}},
+	}
+	assert.NotNil(t, a.Text)
+
+	// Unmarshal a rectangle over it; ensure old fields are cleared.
+	err := json.Unmarshal([]byte(`{"id":"r1","type":"rectangle","border_color":"#000","border_style":"","color":"#fff","thickness":1,"x1":1,"y1":2,"x2":3,"y2":4,"z_index":0,"rotation":0,"border_radius":1}`), &a)
+	assert.NoError(t, err)
+	assert.Equal(t, AnnotationTypeRectangle, a.Type)
+	assert.Nil(t, a.Text)
+	assert.NotNil(t, a.Rectangle)
+	assert.Nil(t, a.Ellipse)
+	assert.Nil(t, a.Line)
+}
+
+func TestAnnotation_Unmarshal_NonObjectJSON(t *testing.T) {
+	var a Annotation
+	err := json.Unmarshal([]byte(`123`), &a)
+	assert.Error(t, err)
+}

--- a/pkg/models/imagedef_test.go
+++ b/pkg/models/imagedef_test.go
@@ -37,3 +37,39 @@ func TestImageDefinition_Unmarshal_Schema210Fields(t *testing.T) {
 	assert.Equal(t, "IOSv", id.Label)
 	assert.Equal(t, "d1.qcow2", id.DiskImage1())
 }
+
+func TestImageDefinition_DiskImage1_EmptyWhenNil(t *testing.T) {
+	id := ImageDefinition{ID: "img1"}
+	assert.Equal(t, "", id.DiskImage1())
+}
+
+func TestImageDefinition_Unmarshal_MissingDiskImage(t *testing.T) {
+	var id ImageDefinition
+	err := json.Unmarshal([]byte(`{"id":"img1","node_definition_id":"iosv","label":"IOSv","read_only":false}`), &id)
+	assert.NoError(t, err)
+	assert.Nil(t, id.DiskImage)
+	assert.Equal(t, "", id.DiskImage1())
+}
+
+func TestImageDefinition_Unmarshal_NullDiskImage(t *testing.T) {
+	var id ImageDefinition
+	err := json.Unmarshal([]byte(`{"id":"img1","node_definition_id":"iosv","label":"IOSv","disk_image":null,"read_only":false}`), &id)
+	assert.NoError(t, err)
+	assert.Nil(t, id.DiskImage)
+	assert.Equal(t, "", id.DiskImage1())
+}
+
+func TestImageDefinition_Unmarshal_OmitsOptionalFields(t *testing.T) {
+	var id ImageDefinition
+	err := json.Unmarshal([]byte(`{
+		"id":"img1",
+		"node_definition_id":"iosv",
+		"label":"IOSv",
+		"disk_image":"d1.qcow2",
+		"read_only":false
+	}`), &id)
+	assert.NoError(t, err)
+	assert.Equal(t, "d1.qcow2", id.DiskImage1())
+	assert.Equal(t, "", id.SchemaVersion)
+	assert.Equal(t, "", id.Description)
+}


### PR DESCRIPTION
This PR improves client authentication, increases test coverage for edge cases,
and adds consistent linting in both CI and local workflows.

Changes:
- feat(auth): add a static-token authentication method via StaticTokenProvider
  and WithStaticToken; tighten auth error handling.
- test(logging): add tests for SetDefault(nil) and Debug/Info/Warn/Error wrapper
  behavior; add model tests for annotation union handling and ImageDefinition
  disk_image nil/missing/unmarshal behavior.
- ci: add a GitHub Actions lint job (go vet + golangci-lint) and add Makefile
  targets (test/vet/lint); update README linting instructions.

Why:
- Support token-based auth flows without extra auth endpoint calls.
- Catch regressions in JSON (un)marshal edge cases and logging wiring.
- Ensure consistent lint enforcement locally and in CI.